### PR TITLE
Make contributing easier

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,3 +231,55 @@ are some places you can find the games listed in this database:
 - [David Winter's CHIP-8 games](https://www.pong-story.com/chip8/): A collection
   of David Winter's games, which are traditionally included in many emulators
   today.
+
+## Contributing
+
+### Prerequisites
+
+This project uses [NPM][] to manage dependencies and run scripts, including
+[jsonschema](https://www.npmjs.com/package/jsonschema) and
+[Prettier](https://prettier.io/). Follow the instructions to
+[download and install npm on your system](https://nodejs.org/en/download/package-manager).
+
+Once NPM is installed, navigate to the root of this repository and execute
+`npm install` to install this project's dependencies.
+
+### Updating the Database from Octo
+
+The CI system checks to ensure that the database is up to date with the contents
+of the [CHIP-8 Archive], and will fail if there are programs there that are not
+listed in [`programs.json`](./database/programs.json).
+
+Before making your changes, it is advised that you run `npm start` to
+automatically create entries for the new files.
+
+If there are any changes (check with `git status` or `git diff`), review the
+newly generated entries at the end of
+[`programs.json`](./database/programs.json) and perform any cleanup that needs
+to occur. In particular, determine appropriate values for the `"platforms"`
+section for each newly added program.
+
+If you made any changes, run `npm run format` before committing.
+
+### Adding a new program
+
+Edit [`programs.json`](./database/programs.json) and add a new object at the end
+of the array. Include data for at least the following keys:
+
+- `title`
+- `description`
+- `authors`
+- `release`
+- `roms.{hash}.file`
+- `roms.{hash}.platforms`
+
+If you are familiar with
+[JSON Schema](https://json-schema.org/understanding-json-schema), review
+[`schemas/programs.json`](./schemas/programs.json) for type definitions and
+validation info.
+
+Otherwise you can look at existing entries and use `npm run test` to
+automatically validate against the schema.
+
+Once you're done making your changes, run `npm start` and `npm run format`
+before committing.

--- a/README.md
+++ b/README.md
@@ -263,8 +263,11 @@ If you made any changes, run `npm run format` before committing.
 
 ### Adding a new program
 
-Edit [`programs.json`](./database/programs.json) and add a new object at the end
-of the array. Include data for at least the following keys:
+Edit [`programs.json`](./database/programs.json) and add a new object **at the
+end** of the array. If you insert a new item in the middle (i.e. alphabetically)
+it will change existing data that comes afterward.
+
+Include data for at least the following keys:
 
 - `title`
 - `description`

--- a/README.md
+++ b/README.md
@@ -244,19 +244,6 @@ scripts, including [jsonschema](https://www.npmjs.com/package/jsonschema) and
 Once NPM is installed, navigate to the root of this repository and execute
 `npm install` to install this project's dependencies.
 
-### Updating the Database from the [CHIP-8 Archive](https://github.com/JohnEarnest/Chip8Archive)
-
-To update the database with new entries from the CHIP-8 Archive, use
-`npm run update`.
-
-If there are any changes (check with `git status` or `git diff`), review the
-newly generated entries at the end of
-[`programs.json`](./database/programs.json) and perform any cleanup that needs
-to occur. In particular, determine appropriate values for the `"platforms"`
-section for each newly added program.
-
-Before committing any changes, run `npm start` and ensure `npm test` passes.
-
 ### Adding a new program
 
 Edit [`programs.json`](./database/programs.json) and add a new object **at the
@@ -279,3 +266,16 @@ validation info.
 
 Once you're done making your changes, run `npm start` and ensure `npm test`
 passes before committing.
+
+### Updating the Database from the [CHIP-8 Archive](https://github.com/JohnEarnest/Chip8Archive)
+
+To update the database with new entries from the CHIP-8 Archive, use
+`npm run update`.
+
+If there are any changes (check with `git status` or `git diff`), review the
+newly generated entries at the end of
+[`programs.json`](./database/programs.json) and perform any cleanup that needs
+to occur. In particular, determine appropriate values for the `"platforms"`
+section for each newly added program.
+
+Before committing any changes, run `npm start` and ensure `npm test` passes.

--- a/README.md
+++ b/README.md
@@ -236,8 +236,8 @@ are some places you can find the games listed in this database:
 
 ### Prerequisites
 
-This project uses [NPM][] to manage dependencies and run scripts, including
-[jsonschema](https://www.npmjs.com/package/jsonschema) and
+This project uses [NPM](https://www.npmjs.com/) to manage dependencies and run
+scripts, including [jsonschema](https://www.npmjs.com/package/jsonschema) and
 [Prettier](https://prettier.io/). Follow the instructions to
 [download and install npm on your system](https://nodejs.org/en/download/package-manager).
 

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ scripts, including [jsonschema](https://www.npmjs.com/package/jsonschema) and
 Once NPM is installed, navigate to the root of this repository and execute
 `npm install` to install this project's dependencies.
 
-### Updating the Database from Octo
+### Updating the Database from the [CHIP-8 Archive](https://github.com/JohnEarnest/Chip8Archive)
 
 The CI system checks to ensure that the database is up to date with the contents
 of the [CHIP-8 Archive], and will fail if there are programs there that are not

--- a/README.md
+++ b/README.md
@@ -246,12 +246,8 @@ Once NPM is installed, navigate to the root of this repository and execute
 
 ### Updating the Database from the [CHIP-8 Archive](https://github.com/JohnEarnest/Chip8Archive)
 
-The CI system checks to ensure that the database is up to date with the contents
-of the [CHIP-8 Archive], and will fail if there are programs there that are not
-listed in [`programs.json`](./database/programs.json).
-
-Before making your changes, it is advised that you run `npm start` to
-automatically create entries for the new files.
+To update the database with new entries from the CHIP-8 Archive, use
+`npm run update`.
 
 If there are any changes (check with `git status` or `git diff`), review the
 newly generated entries at the end of
@@ -259,7 +255,7 @@ newly generated entries at the end of
 to occur. In particular, determine appropriate values for the `"platforms"`
 section for each newly added program.
 
-If you made any changes, run `npm run format` before committing.
+Before committing any changes, run `npm start` and ensure `npm test` passes.
 
 ### Adding a new program
 
@@ -281,8 +277,5 @@ If you are familiar with
 [`schemas/programs.json`](./schemas/programs.json) for type definitions and
 validation info.
 
-Otherwise you can look at existing entries and use `npm run test` to
-automatically validate against the schema.
-
-Once you're done making your changes, run `npm start` and `npm run format`
-before committing.
+Once you're done making your changes, run `npm start` and ensure `npm test`
+passes before committing.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,11 @@
       "name": "Timendus",
       "email": "mail@timendus.com",
       "url": "https://github.com/Timendus"
+    },
+    {
+      "name": "Estus",
+      "email": "git@estus.dev",
+      "url": "https://github.com/Estus-Dev"
     }
   ],
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -3,8 +3,10 @@
   "version": "0.0.1",
   "description": "A database of CHIP-8 game metadata",
   "scripts": {
-    "start": "npm run update-chip8-archive && npm run generate-hashes-file && npm run check-formatting && npm run test",
-    "test": "node ./scripts/validate.js",
+    "start": "npm run generate-hashes-file && npm run format",
+    "update": "npm run update-chip8-archive && npm run generate-hashes-file && npm run check-formatting && npm run test",
+    "test": "npm run validate-schema && npm run check-formatting",
+    "validate-schema": "node ./scripts/validate.js",
     "check-formatting": "prettier --check .",
     "format": "prettier --write .",
     "update-chip8-archive": "node ./scripts/update-chip8-archive.js",

--- a/scripts/update-chip8-archive.js
+++ b/scripts/update-chip8-archive.js
@@ -83,17 +83,25 @@ function cleanedROM(archiveProgram) {
       allowedROMOptions[property]
     );
   }
-  result.colors = {
-    pixels: [
-      cast(archiveProgram.options.backgroundColor, "color") || "missing color",
-      cast(archiveProgram.options.fillColor, "color") || "missing color",
-      cast(archiveProgram.options.fillColor2, "color") || "missing color",
-      cast(archiveProgram.options.blendColor, "color") || "missing color",
-    ],
-    buzzer: cast(archiveProgram.options.buzzColor, "color"),
-    silence: cast(archiveProgram.options.quietColor, "color"),
-  };
-  if (!result.platforms.includes("xochip")) result.colors.pixels.splice(2);
+  let { backgroundColor, fillColor, fillColor2, blendColor } =
+    archiveProgram.options;
+  backgroundColor = cast(backgroundColor, "color");
+  fillColor = cast(fillColor, "color");
+  if (backgroundColor && fillColor) {
+    result.colors = {
+      pixels: [backgroundColor, fillColor],
+      buzzer: cast(archiveProgram.options.buzzColor, "color"),
+      silence: cast(archiveProgram.options.quietColor, "color"),
+    };
+    fillColor2 = cast(fillColor2, "color");
+    blendColor = cast(blendColor, "color");
+    if (result.platforms.includes("xochip") && fillColor2 && blendColor) {
+      result.colors.pixels.push(fillColor2);
+      result.colors.pixels.push(blendColor);
+    }
+  } else {
+    delete result.colors;
+  }
   if (result.screenRotation == "0") delete result.screenRotation;
   return result;
 }


### PR DESCRIPTION
I've added a [Contributing section to the README](./README.md#Contributing), detailing how to add new programs to the list without being rejected by CI.

I've also fixed a bug that's bitten me both times I've contributed in the past, where `scripts/update-chip8-archive.js` would inject invalid colors into existing entries, causing schema validation to fail.

This was caused by the Chip8Archive's `programs.json` file containing programs where no colors were specified.

In future I'd like to automatically create _(draft)_ PRs for updates to the Chip8Archive, at which point we could remove that source of friction from new manual PRs and simplify the README I just added.