### PR TITLE
Fix syzygy platform, chip48 instead of originalChip8

### DIFF
--- a/database/programs.json
+++ b/database/programs.json
@@ -972,7 +972,7 @@
     "roms": {
       "1bdb4ddaa7049266fa3226851f28855a365cfd12": {
         "file": "Syzygy [Roy Trevino, 1990].ch8",
-        "platforms": ["originalChip8"]
+        "platforms": ["chip48"]
       }
     }
   },


### PR DESCRIPTION
As mentioned in [the description of the ROM](https://github.com/chip-8/chip-8-database/blob/master/database/programs.json#L969):

> "This is a CHIP48 version of SYZYGY."

It doesn't work properly when treated as an original CHIP-8 ROM because it relies on the "memoryLeaveIUnchanged" quirk being enabled.
